### PR TITLE
Dockerfile: single RUN for install / Stretch / python3-pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,15 @@
 FROM debian:jessie-slim
 
-# install python + pip
-RUN apt-get update && \
-    apt-get install -y python3 curl && \
+# Install Python, pip, boto3 and python-systemd.
+RUN BUILD_DEPS="curl python3-dev pkg-config gcc git libsystemd-journal-dev" \
+    VERSION="233"; \
+    apt-get update && \
+    apt-get install -y python3 $BUILD_DEPS && \
     curl --fail 'https://bootstrap.pypa.io/get-pip.py' | python3 && \
-    apt-get purge --auto-remove -y curl && \
-    rm -rf /var/lib/apt/lists/*
-
-# install python-systemd
-ENV BUILD_DEPS="python3-dev pkg-config gcc git libsystemd-journal-dev" \
-    VERSION="233"
-RUN apt-get update && \
-    apt-get install -y $BUILD_DEPS && \
-    pip3 install "git+https://github.com/systemd/python-systemd.git/@v$VERSION#egg=systemd" && \
+    pip3 install --no-cache-dir boto3 "git+https://github.com/systemd/python-systemd.git/@v$VERSION#egg=systemd" && \
     apt-get purge --auto-remove -y $BUILD_DEPS && \
+    pip3 uninstall --yes pip && \
     rm -rf /var/lib/apt/lists/*
-
-# install boto3
-RUN pip3 install boto3
 
 COPY main.py /main.py
 ENTRYPOINT ["python3", "/main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 
 # Install Python, pip, boto3 and python-systemd.
-RUN BUILD_DEPS="curl python3-dev pkg-config gcc git libsystemd-journal-dev" \
+RUN BUILD_DEPS="curl python3-dev pkg-config gcc git libsystemd-dev" \
     VERSION="233"; \
     apt-get update && \
     apt-get install -y python3 $BUILD_DEPS && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM debian:stretch-slim
 
 # Install Python, pip, boto3 and python-systemd.
-RUN BUILD_DEPS="curl python3-dev pkg-config gcc git libsystemd-dev" \
+RUN BUILD_DEPS="curl python3-dev python3-pip python3-setuptools pkg-config \
+      gcc git libsystemd-dev" \
     VERSION="233"; \
     apt-get update && \
-    apt-get install -y python3 $BUILD_DEPS && \
-    curl --fail 'https://bootstrap.pypa.io/get-pip.py' | python3 && \
+    apt-get install --no-install-recommends --yes python3 $BUILD_DEPS && \
     pip3 install --no-cache-dir boto3 "git+https://github.com/systemd/python-systemd.git/@v$VERSION#egg=systemd" && \
     apt-get purge --auto-remove -y $BUILD_DEPS && \
-    pip3 uninstall --yes pip && \
     rm -rf /var/lib/apt/lists/*
 
 COPY main.py /main.py

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,3 +1,5 @@
 FROM journald-2-cloudwatch
-RUN pip3 install moto coverage coveralls
+
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools
+RUN pip3 --no-cache-dir install moto coverage coveralls
 ENTRYPOINT ["coverage", "run", "--source=main", "--branch", "-m", "unittest"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,3 +1,3 @@
 FROM journald-2-cloudwatch
-RUN pip install moto coverage coveralls
+RUN pip3 install moto coverage coveralls
 ENTRYPOINT ["coverage", "run", "--source=main", "--branch", "-m", "unittest"]


### PR DESCRIPTION
Speeds up build, and reduces image size from 168MB to 154MB.